### PR TITLE
Fix CI Build

### DIFF
--- a/TestCOMServer/TestCOMServer.sln
+++ b/TestCOMServer/TestCOMServer.sln
@@ -10,15 +10,9 @@ Global
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Debug-Appveyor|Any CPU = Debug-Appveyor|Any CPU
-		Debug-Appveyor|x64 = Debug-Appveyor|x64
-		Debug-Appveyor|x86 = Debug-Appveyor|x86
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-		Release-Appveyor|Any CPU = Release-Appveyor|Any CPU
-		Release-Appveyor|x64 = Release-Appveyor|x64
-		Release-Appveyor|x86 = Release-Appveyor|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -27,24 +21,12 @@ Global
 		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Debug|x64.Build.0 = Debug|x64
 		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Debug|x86.ActiveCfg = Debug|x86
 		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Debug|x86.Build.0 = Debug|x86
-		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Debug-Appveyor|Any CPU.ActiveCfg = Debug-Appveyor|Any CPU
-		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Debug-Appveyor|Any CPU.Build.0 = Debug-Appveyor|Any CPU
-		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Debug-Appveyor|x64.ActiveCfg = Debug-Appveyor|x64
-		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Debug-Appveyor|x64.Build.0 = Debug-Appveyor|x64
-		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Debug-Appveyor|x86.ActiveCfg = Debug-Appveyor|x86
-		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Debug-Appveyor|x86.Build.0 = Debug-Appveyor|x86
 		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Release|x64.ActiveCfg = Release|Any CPU
 		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Release|x64.Build.0 = Release|Any CPU
 		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Release|x86.ActiveCfg = Release|x86
 		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Release|x86.Build.0 = Release|x86
-		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Release-Appveyor|Any CPU.ActiveCfg = Release-Appveyor|Any CPU
-		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Release-Appveyor|Any CPU.Build.0 = Release-Appveyor|Any CPU
-		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Release-Appveyor|x64.ActiveCfg = Release-Appveyor|x64
-		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Release-Appveyor|x64.Build.0 = Release-Appveyor|x64
-		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Release-Appveyor|x86.ActiveCfg = Release-Appveyor|x86
-		{AC11D114-EBEE-4D2F-B968-127F155E4F6E}.Release-Appveyor|x86.Build.0 = Release-Appveyor|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TestCOMServer/TestCOMServer/TestCOMServer.csproj
+++ b/TestCOMServer/TestCOMServer/TestCOMServer.csproj
@@ -144,23 +144,22 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if "Debug-Appveyor" == "$(ConfigurationName)" (call "$(VS100COMNTOOLS)vsvars32.bat" $(PlatformName)
+    <PostBuildEvent>if "Debug-Appveyor" == "$(ConfigurationName)" (call "$(VS100COMNTOOLS)vsvars32.bat"
 )
 
 
-if "Release-Appveyor" == "$(ConfigurationName)" (call "$(VS100COMNTOOLS)vsvars32.bat" $(PlatformName)
+if "Release-Appveyor" == "$(ConfigurationName)" (call "$(VS100COMNTOOLS)vsvars32.bat"
 )
 
 
-if "Debug" == "$(ConfigurationName)" (call "$(DevEnvDir)..\Tools\vsvars32.bat" $(PlatformName)
+if "Debug" == "$(ConfigurationName)" (call "$(DevEnvDir)..\Tools\vsvars32.bat"
 )
 
 
-if "Release" == "$(ConfigurationName)" (call "$(DevEnvDir)..\Tools\vsvars32.bat" $(PlatformName)
+if "Release" == "$(ConfigurationName)" (call "$(DevEnvDir)..\Tools\vsvars32.bat"
 )
-
-
-tlbexp $(TargetFileName) /nologo</PostBuildEvent>
+if "x32" == $(PlatformName)" (tlbexp $(TargetFileName) /nologo)
+if "x64" == $(PlatformName)" (tlbexp $(TargetFileName) /nologo /win64)</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/TestCOMServer/TestCOMServer/TestCOMServer.csproj
+++ b/TestCOMServer/TestCOMServer/TestCOMServer.csproj
@@ -144,17 +144,21 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if "Debug-Appveyor" == "$(ConfigurationName)" (call "$(VS100COMNTOOLS)VsDevCmd.bat" $(PlatformName)
+    <PostBuildEvent>if "Debug-Appveyor" == "$(ConfigurationName)" (call "$(VS100COMNTOOLS)vsvars32.bat" $(PlatformName)
 )
 
-if "Release-Appveyor" == "$(ConfigurationName)" (call "$(VS100COMNTOOLS)VsDevCmd.bat" $(PlatformName)
+
+if "Release-Appveyor" == "$(ConfigurationName)" (call "$(VS100COMNTOOLS)vsvars32.bat" $(PlatformName)
 )
 
-if "Debug" == "$(ConfigurationName)" (call "$(DevEnvDir)..\Tools\VsDevCmd.bat" $(PlatformName)
+
+if "Debug" == "$(ConfigurationName)" (call "$(DevEnvDir)..\Tools\vsvars32.bat" $(PlatformName)
 )
 
-if "Release" == "$(ConfigurationName)" (call "$(DevEnvDir)..\Tools\VsDevCmd.bat" $(PlatformName)
+
+if "Release" == "$(ConfigurationName)" (call "$(DevEnvDir)..\Tools\vsvars32.bat" $(PlatformName)
 )
+
 
 tlbexp $(TargetFileName) /nologo</PostBuildEvent>
   </PropertyGroup>

--- a/TestCOMServer/TestCOMServer/TestCOMServer.csproj
+++ b/TestCOMServer/TestCOMServer/TestCOMServer.csproj
@@ -16,22 +16,22 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin\AnyCPU\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <RegisterForComInterop>false</RegisterForComInterop>
-    <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin\AnyCPU\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <RegisterForComInterop>false</RegisterForComInterop>
-    <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -39,7 +39,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
@@ -51,7 +51,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -59,7 +59,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
-    <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
@@ -71,7 +71,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/TestCOMServer/TestCOMServer/TestCOMServer.csproj
+++ b/TestCOMServer/TestCOMServer/TestCOMServer.csproj
@@ -144,11 +144,14 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if "" != "$(VS100COMNTOOLS)" (SET VSVARSALL=$(VS100COMNTOOLS)..\..\VC\vsvarsall.bat)
-if "" != "$(DevEnvDir)" (SET VSVARSALL=$(DevEnvDir)..\..\vsvarsall.bat)
-
-if "x32" == "$(PlatformName)" (call $(VSVARSALL) x86)
-if "x64" == "$(PlatformName)" (call $(VSVARSALL) amd64)
+    <PostBuildEvent>if not "" == "$(VS100COMNTOOLS)" (
+    if "x86" == "$(PlatformName)" (call "$(VS100COMNTOOLS)..\..\VC\vcvarsall.bat" x86)
+    if "x64" == "$(PlatformName)" (call "$(VS100COMNTOOLS)..\..\VC\vcvarsall.bat" amd64)
+)
+if not "*Undefined*" == "$(DevEnvDir)" (
+    if "x86" == "$(PlatformName)" (call "$(DevEnvDir)..\..\VC\vcvarsall.bat" x86)
+    if "x64" == "$(PlatformName)" (call "$(DevEnvDir)..\..\VC\vcvarsall.bat" amd64)
+)
 
 tlbexp $(TargetFileName) /nologo</PostBuildEvent>
   </PropertyGroup>

--- a/TestCOMServer/TestCOMServer/TestCOMServer.csproj
+++ b/TestCOMServer/TestCOMServer/TestCOMServer.csproj
@@ -73,66 +73,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-Appveyor|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug-Appveyor\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-Appveyor|x64'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug-Appveyor\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-Appveyor|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug-Appveyor\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-Appveyor|AnyCPU'">
-    <OutputPath>bin\Release-Appveyor\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-Appveyor|x64'">
-    <OutputPath>bin\x64\Release-Appveyor\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-Appveyor|x86'">
-    <OutputPath>bin\x86\Release-Appveyor\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -144,16 +84,11 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if not "" == "$(VS100COMNTOOLS)" (
-    if "x86" == "$(PlatformName)" (call "$(VS100COMNTOOLS)..\..\VC\vcvarsall.bat" x86)
-    if "x64" == "$(PlatformName)" (call "$(VS100COMNTOOLS)..\..\VC\vcvarsall.bat" amd64)
-)
-if not "*Undefined*" == "$(DevEnvDir)" (
-    if "x86" == "$(PlatformName)" (call "$(DevEnvDir)..\..\VC\vcvarsall.bat" x86)
-    if "x64" == "$(PlatformName)" (call "$(DevEnvDir)..\..\VC\vcvarsall.bat" amd64)
-)
-
-tlbexp $(TargetFileName) /nologo</PostBuildEvent>
+    <PostBuildEvent>if not "" == "$(VS100COMNTOOLS)" (call "$(VS100COMNTOOLS)..\..\VC\vcvarsall.bat" x86)
+if not "*Undefined*" == "$(DevEnvDir)" (call "$(DevEnvDir)..\..\VC\vcvarsall.bat" x86)
+if "x86" == "$(PlatformName)" (tlbexp $(TargetFileName) /nologo /win32)
+if "x64" == "$(PlatformName)" (tlbexp $(TargetFileName) /nologo /win64)
+if "Any CPU" == "$(PlatformName)" (tlbexp $(TargetFileName) /nologo)</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/TestCOMServer/TestCOMServer/TestCOMServer.csproj
+++ b/TestCOMServer/TestCOMServer/TestCOMServer.csproj
@@ -144,22 +144,26 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if "Debug-Appveyor" == "$(ConfigurationName)" (call "$(VS100COMNTOOLS)vsvars32.bat"
-)
+    <PostBuildEvent>if "Debug-Appveyor" == "$(ConfigurationName)" (call "$(VS100COMNTOOLS)vsvars32.bat")
+
 
 
 if "Release-Appveyor" == "$(ConfigurationName)" (call "$(VS100COMNTOOLS)vsvars32.bat"
 )
 
 
+
 if "Debug" == "$(ConfigurationName)" (call "$(DevEnvDir)..\Tools\vsvars32.bat"
 )
 
 
+
 if "Release" == "$(ConfigurationName)" (call "$(DevEnvDir)..\Tools\vsvars32.bat"
 )
-if "x32" == $(PlatformName)" (tlbexp $(TargetFileName) /nologo)
-if "x64" == $(PlatformName)" (tlbexp $(TargetFileName) /nologo /win64)</PostBuildEvent>
+
+if "x32" == "$(PlatformName)" (tlbexp $(TargetFileName) /nologo)
+
+if "x64" == "$(PlatformName)" (tlbexp $(TargetFileName) /nologo /win64)</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/TestCOMServer/TestCOMServer/TestCOMServer.csproj
+++ b/TestCOMServer/TestCOMServer/TestCOMServer.csproj
@@ -88,7 +88,7 @@
 if not "*Undefined*" == "$(DevEnvDir)" (call "$(DevEnvDir)..\..\VC\vcvarsall.bat" x86)
 if "x86" == "$(PlatformName)" (tlbexp $(TargetFileName) /nologo /win32)
 if "x64" == "$(PlatformName)" (tlbexp $(TargetFileName) /nologo /win64)
-if "Any CPU" == "$(PlatformName)" (tlbexp $(TargetFileName) /nologo)</PostBuildEvent>
+if "AnyCPU" == "$(PlatformName)" (tlbexp $(TargetFileName) /nologo)</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/TestCOMServer/TestCOMServer/TestCOMServer.csproj
+++ b/TestCOMServer/TestCOMServer/TestCOMServer.csproj
@@ -144,26 +144,13 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if "Debug-Appveyor" == "$(ConfigurationName)" (call "$(VS100COMNTOOLS)vsvars32.bat")
+    <PostBuildEvent>if "" != "$(VS100COMNTOOLS)" (SET VSVARSALL=$(VS100COMNTOOLS)..\..\VC\vsvarsall.bat)
+if "" != "$(DevEnvDir)" (SET VSVARSALL=$(DevEnvDir)..\..\vsvarsall.bat)
 
+if "x32" == "$(PlatformName)" (call $(VSVARSALL) x86)
+if "x64" == "$(PlatformName)" (call $(VSVARSALL) amd64)
 
-
-if "Release-Appveyor" == "$(ConfigurationName)" (call "$(VS100COMNTOOLS)vsvars32.bat"
-)
-
-
-
-if "Debug" == "$(ConfigurationName)" (call "$(DevEnvDir)..\Tools\vsvars32.bat"
-)
-
-
-
-if "Release" == "$(ConfigurationName)" (call "$(DevEnvDir)..\Tools\vsvars32.bat"
-)
-
-if "x32" == "$(PlatformName)" (tlbexp $(TargetFileName) /nologo)
-
-if "x64" == "$(PlatformName)" (tlbexp $(TargetFileName) /nologo /win64)</PostBuildEvent>
+tlbexp $(TargetFileName) /nologo</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ version: '1.0.0.{build}-alpha-{branch}'
 
 configuration: Release
 
+skip_tags: true
+
 platform:
 - x86
 - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '1.0.0.{build}-alpha-{branch}'
 
-configuration: Release-Appveyor
+configuration: Release
 
 platform:
 - x86

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,12 @@ build:
   verbosity: normal
 
 after_build:
-- 7z a %APPVEYOR_PROJECT_NAME%-%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\TestCOMServer\TestCOMServer\bin\%PLATFORM%\%CONFIGURATION%\*
+- 7z a %APPVEYOR_PROJECT_NAME%-%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\TestCOMServer\TestCOMServer\bin\*\%CONFIGURATION%\*
 
 artifacts:
-- path: '**\bin\**\$(configuration)\*.dll'
+- path: '**\bin\**\*.dll'
   name: dll
-- path: '**\bin\**\$(configuration)\*.tlb'
+- path: '**\bin\**\*.tlb'
   name: tlb
 - path: '\*.zip'
   name: zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '{branch}.{build}'
+version: '1.0.0.{build}-alpha-{branch}'
 
 configuration: Release-Appveyor
 


### PR DESCRIPTION
* Use vsvarsall.bat.
* Update version name.
* Make sure to create x64 type library when AnyCPU.
* Set the correct vars and simplify post build script.
* Correct path and issues with build script.
* Use release configuration instead and remove Appveyor specific settings.
* Don't build tags.
* Set active platform to x64.